### PR TITLE
Adds API Provisioning step to fix weird login issues

### DIFF
--- a/libdyson/exceptions.py
+++ b/libdyson/exceptions.py
@@ -21,6 +21,10 @@ class DysonLoginFailure(DysonException):
     """Represents failure during logging in."""
 
 
+class DysonAPIProvisionFailure(DysonException):
+    """Represents failure during logging in."""
+
+
 class DysonOTPTooFrequently(DysonException):
     """Represents requesting OTP code too frequently."""
 


### PR DESCRIPTION
### Background

One of the long-lived "bugs" with this project has been with the Dyson login process for cloud services<sup>[1](https://github.com/libdyson-wg/ha-dyson/issues/6), [2](https://github.com/shenxn/ha-dyson-cloud/issues/6)</sup>. For most people, this probably hasn't been a big deal, at least until more recently. Dyson products released in the past year or two don't have stickers with the credentials needed to connect, but the credentials _are_ available from the API. This makes the cloud integration necessary to set up these devices, including:

- Formaldehyde models
- Humidifier models
- The HP07 ~~$200 paint job~~ _update_ of the HP04.

After a few nights of trying to reverse-engineer the API (and learning a LOT about how to actually do this), I got this quick fix that seems to be working just fine.

### What's Changed?

Added what's I've arbitrarily deemed a `provision_api` request at the beginning of any account functions which call the API. The naming is chosen because the API path has "provisioningservice", and in this context it felt more semantically meaningful than something literal like `get_version`.

There doesn't seem to be any downside to frequently hitting the endpoint, so it's just prepended to all the account methods that could hit the API to "protect" them all.

### Other Info

Calling the User Status API initially returns an "Unable to authenticate" error, until after a request for a "version" has been made. Calling this provisioning service version API essentially unlocks the rest of the API.

```sh
> curl -H 'Content-Type: application/json; charset=utf-8' \
       -H 'User-Agent: Dalvik/2.1.0 (Linux; U; Android 13; ONEPLUS A6013 Build/TQ2A.230305.008.C1)' \
       -H 'Connection: Keep-Alive' \
       --compressed \
       -X POST \
       'https://appapi.cp.dyson.com/v3/userregistration/email/userstatus?country=US' \
       -d '{"email":"[REDACTED]"}' | jq

{
  "Message": "Unable to authenticate user."
}

> curl -H 'User-Agent: Dalvik/2.1.0 (Linux; U; Android 13; ONEPLUS A6013 Build/TQ2A.230305.008.C1)' \
       -H 'Connection: Keep-Alive' \
       --compressed \
       https://appapi.cp.dyson.com/v1/provisioningservice/application/Android/version | jq

"5.0.21061"

> curl -H 'Content-Type: application/json; charset=utf-8' \
       -H 'User-Agent: Dalvik/2.1.0 (Linux; U; Android 13; ONEPLUS A6013 Build/TQ2A.230305.008.C1)' \
       -H 'Connection: Keep-Alive' \
       --compressed \
       -X POST \
       'https://appapi.cp.dyson.com/v3/userregistration/email/userstatus?country=US' \
       -d '{"email":"[REDACTED]"}'  | jq

{
  "accountStatus": "ACTIVE",
  "authenticationMethod": "EMAIL_PWD_2FA"
}

```