### PR TITLE
Use the hchr field for Formaldehyde values

### DIFF
--- a/libdyson/cloud/account.py
+++ b/libdyson/cloud/account.py
@@ -6,7 +6,7 @@ from typing import Callable, List, Optional
 import requests
 from requests.auth import AuthBase, HTTPBasicAuth
 
-from libdyson.exceptions import (
+from ..exceptions import (
     DysonAuthRequired,
     DysonInvalidAccountStatus,
     DysonInvalidAuth,

--- a/libdyson/dyson_device.py
+++ b/libdyson/dyson_device.py
@@ -257,13 +257,13 @@ class DysonFanDevice(DysonDevice):
         return self._get_field_value(self._status, "wacd")
 
     @property
-    def formaldehyde(self) -> Optional[int]:
+    def formaldehyde(self) -> Optional[float]:
         """Return formaldehyde reading."""
-        val = self._get_environmental_field_value("hcho")
+        val = self._get_environmental_field_value("hchr", divisor=1000)
         if val is None:
             return None
 
-        return int(val)
+        return float(val)
 
     @property
     def humidity(self) -> int:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = libdyson-neon
-version = 1.0.2
+version = 1.1.0
 author = The libdyson Working Group
 author_email = dotvezz@gmail.com
 license = MIT License

--- a/tests/test_pure_cool_formaldehyde.py
+++ b/tests/test_pure_cool_formaldehyde.py
@@ -66,4 +66,4 @@ def test_properties(mqtt_client: MockedMQTT):
     assert device.particulate_matter_10 == 5
     assert device.volatile_organic_compounds == 0.4
     assert device.nitrogen_dioxide == 1.1
-    assert device.formaldehyde == 1
+    assert device.formaldehyde == 0.002

--- a/tests/test_pure_cool_missing_env_data.py
+++ b/tests/test_pure_cool_missing_env_data.py
@@ -58,7 +58,7 @@ def test_no_hcho(mqtt_client: MockedMQTT):
             "p10r": "0009",
             "sltm": "OFF",
             "hcho": "NONE",
-            "hchr": "0002",
+            "hchr": "NONE",
         }
     }
     device.request_environmental_data()
@@ -92,7 +92,6 @@ def test_missing_data(mqtt_client: MockedMQTT):
             "p25r": "0010",
             "p10r": "0009",
             "sltm": "OFF",
-            "hchr": "0002",
         }
     }
     device.request_environmental_data()

--- a/tests/test_purifier_humidify_cool_formaldehyde.py
+++ b/tests/test_purifier_humidify_cool_formaldehyde.py
@@ -66,4 +66,4 @@ def test_properties(mqtt_client: MockedMQTT):
     assert device.particulate_matter_10 == 5
     assert device.volatile_organic_compounds == .4
     assert device.nitrogen_dioxide == 1.1
-    assert device.formaldehyde == 1
+    assert device.formaldehyde == 0.002


### PR DESCRIPTION
Reference discussion link: https://github.com/libdyson-wg/ha-dyson/issues/4

The `hcho` field in MQTT is of an unknown unit/scale and has no known conversion factor to a known unit. However, it was recently discovered that `hchr` (referred to as "High Res Formaldehyde" in the android app) has a clean conversion factor of n/1000 to mg/m^3.