### PR TITLE
Proper fan mode handling (Dyson Poor Cool Link)

### DIFF
--- a/libdyson/dyson_device.py
+++ b/libdyson/dyson_device.py
@@ -34,6 +34,7 @@ class DysonDevice:
         self._serial = serial
         self._credential = credential
         self._mqtt_client = None
+        self.preset_mode = None
         self._connected = threading.Event()
         self._disconnected = threading.Event()
         self._status = None

--- a/libdyson/dyson_device.py
+++ b/libdyson/dyson_device.py
@@ -34,7 +34,6 @@ class DysonDevice:
         self._serial = serial
         self._credential = credential
         self._mqtt_client = None
-        self.preset_mode = None
         self._connected = threading.Event()
         self._disconnected = threading.Event()
         self._status = None

--- a/libdyson/dyson_pure_cool_link.py
+++ b/libdyson/dyson_pure_cool_link.py
@@ -20,7 +20,11 @@ class DysonPureCoolLink(DysonFanDevice):
     @property
     def auto_mode(self) -> bool:
         """Return auto mode status."""
-        return self.fan_mode == "AUTO"
+        if not self.is_on:
+            return self.preset_mode == "AUTO"
+        else:
+            self.preset_mode = self.fan_mode
+            return self.fan_mode == "AUTO"
 
     @property
     def oscillation(self) -> bool:
@@ -60,10 +64,12 @@ class DysonPureCoolLink(DysonFanDevice):
 
     def enable_auto_mode(self) -> None:
         """Turn on auto mode."""
+        self.preset_mode = "AUTO"
         self._set_configuration(fmod="AUTO")
 
     def disable_auto_mode(self) -> None:
         """Turn off auto mode."""
+        self.preset_mode = "FAN"
         self._set_configuration(fmod="FAN")
 
     def enable_oscillation(self) -> None:

--- a/libdyson/dyson_pure_cool_link.py
+++ b/libdyson/dyson_pure_cool_link.py
@@ -7,6 +7,10 @@ from .dyson_device import DysonFanDevice
 class DysonPureCoolLink(DysonFanDevice):
     """Dyson Pure Cool Link device."""
 
+    def __init__(self, serial: str, credential: str, device_type: str):
+        super().__init__(serial, credential, device_type)
+        self.preset_mode = "FAN"
+
     @property
     def fan_mode(self) -> str:
         """Return the fan mode of the fan."""

--- a/libdyson/dyson_pure_cool_link.py
+++ b/libdyson/dyson_pure_cool_link.py
@@ -28,7 +28,7 @@ class DysonPureCoolLink(DysonFanDevice):
             return self.preset_mode == "AUTO"
         else:
             self.preset_mode = self.fan_mode
-            return self.fan_mode == "AUTO"
+            return self.preset_mode == "AUTO"
 
     @property
     def oscillation(self) -> bool:

--- a/libdyson/dyson_pure_cool_link.py
+++ b/libdyson/dyson_pure_cool_link.py
@@ -53,7 +53,7 @@ class DysonPureCoolLink(DysonFanDevice):
 
     def turn_on(self) -> None:
         """Turn on the device."""
-        self._set_configuration(fmod="FAN")
+        self._set_configuration(fmod=self.preset_mode)
 
     def turn_off(self) -> None:
         """Turn off the device."""


### PR DESCRIPTION
working on https://github.com/libdyson-wg/ha-dyson/issues/70

I don't know how to test these changes, but I think they should work.
I added a `preset_mode` variable to `DysonDevice` class, but probably it should only be in the `Dyson Cool Link` class.
I also don"t know, why the `is_on` method checks `if fan_mode in ["AUTO","FAN"]` and doesn't use `fan_mode != "OFF"`.