### PR TITLE
Check for blank LocalCredentials instead of None during sign in

### DIFF
--- a/libdyson/cloud/account.py
+++ b/libdyson/cloud/account.py
@@ -202,7 +202,7 @@ class DysonAccount:
         devices = []
         response = self.request("GET", API_PATH_DEVICES)
         for raw in response.json():
-            if raw.get("LocalCredentials") is None:
+            if not raw.get("LocalCredentials"):
                 # Lightcycle lights don't have LocalCredentials.
                 # They're not supported so just skip.
                 # See https://github.com/shenxn/libdyson/issues/2 for more info


### PR DESCRIPTION
I couldn't get the auto-setup to work with my "MyDyson" account in either Home Assistant or with the local tool. Upon looking at the trace locally I found this line and figured I'd try changing it from ` is None` to `not` in case the API changed (I have 2 Lightcycles) - as soon as I did it worked fine.