### PR TITLE
Add Dyson Cool CF1 (type 739) support

### DIFF
--- a/libdyson/__init__.py
+++ b/libdyson/__init__.py
@@ -21,6 +21,7 @@ from .const import (
     DEVICE_TYPE_PURIFIER_HUMIDIFY_COOL_E,
     DEVICE_TYPE_PURIFIER_HUMIDIFY_COOL_K,
     DEVICE_TYPE_PURIFIER_BIG_QUIET,
+    DEVICE_TYPE_PURE_COOL_CF1,
 )
 
 from .const import CleaningMode  # noqa: F401
@@ -39,7 +40,7 @@ from .dyson_360_eye import Dyson360Eye
 from .dyson_360_heurist import Dyson360Heurist
 from .dyson_360_vis_nav import Dyson360VisNav
 from .dyson_device import DysonDevice
-from .dyson_pure_cool import DysonPureCool
+from .dyson_pure_cool import DysonPureCool, DysonCoolCF1
 from .dyson_pure_cool_link import DysonPureCoolLink
 from .dyson_pure_hot_cool import DysonPureHotCool
 from .dyson_pure_hot_cool_link import DysonPureHotCoolLink
@@ -102,6 +103,9 @@ def get_device(serial: str, credential: str, device_type: str) -> Optional[Dyson
     }:
         _LOGGER.debug("Creating DysonBigQuiet device")
         return DysonBigQuiet(serial, credential, device_type)
+    if device_type == DEVICE_TYPE_PURE_COOL_CF1:
+        _LOGGER.debug("Creating DysonCoolCF1 device")
+        return DysonCoolCF1(serial, credential, device_type)
     
     _LOGGER.warning("Unknown device type: %s for serial: %s", device_type, serial)
     return None

--- a/libdyson/const.py
+++ b/libdyson/const.py
@@ -20,6 +20,7 @@ DEVICE_TYPE_PURIFIER_HOT_COOL_E = "527E"  # Deprecated: use DEVICE_TYPE_PURE_HOT
 DEVICE_TYPE_PURIFIER_HOT_COOL_K = "527K"  # Deprecated: use DEVICE_TYPE_PURE_HOT_COOL instead (kept for MQTT topic compatibility)
 DEVICE_TYPE_PURIFIER_HOT_COOL_M = "527M"  # Deprecated: use DEVICE_TYPE_PURE_HOT_COOL instead (kept for MQTT topic compatibility)
 DEVICE_TYPE_PURIFIER_BIG_QUIET = "664"  # BP02, BP03, and BP04
+DEVICE_TYPE_PURE_COOL_CF1 = "739"  # CF1 - Dyson Cool desk fan (no air-quality sensors or filter)
 
 DEVICE_TYPE_NAMES = {
     DEVICE_TYPE_360_EYE: "360 Eye robot vacuum",
@@ -39,7 +40,8 @@ DEVICE_TYPE_NAMES = {
     DEVICE_TYPE_PURIFIER_HUMIDIFY_COOL_K: "Purifier Humidify+Cool K Series (Deprecated - use Pure Humidify+Cool)",
     DEVICE_TYPE_PURIFIER_HUMIDIFY_COOL_E: "Purifier Humidify+Cool E Series (Deprecated - use Pure Humidify+Cool)",
     DEVICE_TYPE_PURIFIER_HOT_COOL_K: "Purifier Hot+Cool K Series (Deprecated - use Pure Hot+Cool)",
-    DEVICE_TYPE_PURIFIER_BIG_QUIET: "Purifier Big+Quiet Series"
+    DEVICE_TYPE_PURIFIER_BIG_QUIET: "Purifier Big+Quiet Series",
+    DEVICE_TYPE_PURE_COOL_CF1: "Cool CF1",
 }
 
 ENVIRONMENTAL_OFF = -1

--- a/libdyson/dyson_pure_cool.py
+++ b/libdyson/dyson_pure_cool.py
@@ -43,14 +43,17 @@ class DysonPureCoolBase(DysonFanDevice):
     def carbon_filter_life(self) -> Optional[int]:
         """Return carbon filter life in percentage."""
         filter_life = self._get_field_value(self._status, "cflr")
-        if filter_life == "INV":
+        if filter_life is None or filter_life == "INV":
             return None
         return int(filter_life)
 
     @property
     def hepa_filter_life(self) -> Optional[int]:
         """Return HEPA filter life in percentage."""
-        return int(self._get_field_value(self._status, "hflr"))
+        filter_life = self._get_field_value(self._status, "hflr")
+        if filter_life is None or filter_life == "INV":
+            return None
+        return int(filter_life)
 
     @property
     def particulate_matter_2_5(self):
@@ -175,3 +178,13 @@ class DysonPureCool(DysonPureCoolBase):
         else:
             oson = "OFF"
         self._set_configuration(oson=oson)
+
+
+class DysonCoolCF1(DysonPureCool):
+    """Dyson Cool CF1 desk fan.
+
+    Shares the Pure Cool control surface (fpwr/fnsp/oson/osal/osau/ancp), but
+    unlike the purifier models it has no air-quality sensors and no filter, so
+    those fields are absent from its status payload. Exposed as its own class so
+    integrations can avoid creating empty sensor/filter entities for it.
+    """


### PR DESCRIPTION
## What
Adds support for the **Dyson Cool CF1** desk fan (product type `739`).
  
## Why
`get_device()` currently returns `None` for type `739`, so the CF1 can't be set up. The CF1 speaks the standard Pure Cool MQTT protocol, but it's a cooling-only fan — no air-quality sensors and no filter.
  
## Changes
- `const.py`: add `DEVICE_TYPE_PURE_COOL_CF1 = "739"` and its display name.
- `dyson_pure_cool.py`: add `DysonCoolCF1(DysonPureCool)`; make `carbon_filter_life` / `hepa_filter_life` null-safe — filterless models omit the `cflr`/`hflr` fields, so `int(None)` raised `TypeError` during capability probing / sensor setup.
- `__init__.py`: map `739 → DysonCoolCF1`.
  
## Testing
Verified against a real CF1 (firmware `0739PF.01.01.005.x`) over local MQTT: 
- `CURRENT-STATE` returns the Pure Cool control fields (`fpwr`/`fnsp`/`oson`/`oscs`/`osal`/`osau`/`ancp`).
- `ENVIRONMENTAL-CURRENT-SENSOR-DATA` carries no sensor data — confirming there are no sensors/filter to read.
- With this change the fan sets up and power / speed / oscillation control work.